### PR TITLE
Update Contextual Category Widget to 0.7.0

### DIFF
--- a/pg/composer.json
+++ b/pg/composer.json
@@ -33,7 +33,7 @@
     "johnpbloch/wordpress-core-installer": "^2.0",
     "platformsh/config-reader": "^3.0",
     "wpackagist-plugin/akismet": "^5.0",
-    "wpackagist-plugin/contextual-category-widget": "^0.6.1",
+    "wpackagist-plugin/contextual-category-widget": "^0.7.0",
     "wpackagist-plugin/mailchimp-for-wp": "^4.10",
     "wpackagist-plugin/redis-cache": "^2.8",
     "wpackagist-plugin/redirection": "^5.8",

--- a/pg/composer.lock
+++ b/pg/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "763410bbf2e230ecf6f24a3c28360d6c",
+    "content-hash": "39e48571e758521a4bd8de7aad3605c0",
     "packages": [
         {
             "name": "artetecha/upsun-wp",
@@ -427,15 +427,15 @@
         },
         {
             "name": "wpackagist-plugin/contextual-category-widget",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/contextual-category-widget/",
-                "reference": "tags/0.6.1"
+                "reference": "tags/0.7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/contextual-category-widget.0.6.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/contextual-category-widget.0.7.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
## Summary

- update the Composer constraint from `^0.6.1` to `^0.7.0`
- lock Contextual Category Widget 0.7.0 from its WordPress.org release tag
- keep the existing plugin activation configuration unchanged

## Compatibility

The release supports WordPress 6.0+ and PHP 7.4+. Pergrazia currently runs WordPress 7.0.2 and PHP 8.4.

## Validation

- Composer manifest and lockfile validation
- complete production install dry-run
- Composer security advisory check
- Git whitespace validation

Release: https://github.com/artetecha/contextual-category-widget/releases/tag/0.7.0